### PR TITLE
Resize src image to match widget rect

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,20 +1,40 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:optimized_cached_image/cache_manager/resize_cache_manager.dart';
 import 'package:optimized_cached_image/image_cache_manager.dart';
 import 'package:optimized_cached_image/widgets.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:tuple/tuple.dart';
 
 void main() => runApp(MyApp());
 
-class MyApp extends StatefulWidget {
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'CachedNetworkImage Demo',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
   @override
   _MyAppState createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyHomePage> {
   final urlPrefix = "https://i.picsum.photos/id/";
   final urlSuffix = "/1000/1000.jpg";
+  String currentPage = 'Optimized Cached Image Example';
+
+  void _select(Tuple2 choice) {
+    setState(() {
+      currentPage = choice.item1;
+    });
+  }
 
   @override
   void initState() {
@@ -31,11 +51,34 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Optimized Cached Image Example'),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(16.0),
+          appBar: AppBar(title: Text(currentPage), actions: <Widget>[
+            IconButton(
+              icon: Icon(_menuEntries[0].item2),
+              onPressed: () {
+                _select(_menuEntries[0]);
+              },
+            ),
+          ]),
+          body: _page(currentPage)),
+    );
+  }
+
+  Widget _page(String page) {
+    switch (page) {
+      case 'Grid':
+        {
+          return _gridPage();
+        }
+    }
+
+    return _homePage();
+  }
+
+  Widget _homePage() {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: SingleChildScrollView(
+        child: Center(
           child: Column(
             children: <Widget>[
               SizedBox(
@@ -47,6 +90,11 @@ class _MyAppState extends State<MyApp> {
               // detects it based on its parent's constraints.
               OptimizedCacheImage(
                 imageUrl: "https://i.picsum.photos/id/110/1000/300.jpg",
+              ),
+              OptimizedCacheImage(
+                imageUrl: "https://i.picsum.photos/id/155/2000/1000.jpg",
+                cacheManager: ResizeImageCacheManager(),
+                fit: BoxFit.cover,
               ),
               SizedBox(
                 height: 20,
@@ -63,7 +111,7 @@ class _MyAppState extends State<MyApp> {
               Image(
                 image: OptimizedCacheImageProvider(
                     "https://cdn.pixabay.com/photo/2015/03/26/09/47/sky-690293__340.jpg",
-                    useScaleCacheManager: false,
+                    cacheManager: ImageCacheManager(),
                     cacheHeight: 50,
                     cacheWidth: 20),
               ),
@@ -73,4 +121,42 @@ class _MyAppState extends State<MyApp> {
       ),
     );
   }
+
+  Widget _gridPage() {
+    final _resizeCacheManager = ResizeImageCacheManager();
+    final Orientation orientation = MediaQuery.of(context).orientation;
+    final axisCount = (orientation == Orientation.portrait) ? 2 : 3;
+    return GridView.builder(
+      itemCount: 1000,
+      padding: const EdgeInsets.all(4.0),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: axisCount,
+        mainAxisSpacing: 4.0,
+        crossAxisSpacing: 4.0,
+      ),
+      itemBuilder: (BuildContext context, int index) => OptimizedCacheImage(
+        cacheManager: _resizeCacheManager,
+        imageUrl: 'https://loremflickr.com/1024/640/music?lock=$index',
+        placeholder: _loader,
+        errorWidget: _error,
+        fit: BoxFit.cover,
+      ),
+    );
+  }
+
+  Widget _loader(BuildContext context, String url) {
+    return const Center(
+      child: CircularProgressIndicator(),
+    );
+  }
+
+  Widget _error(BuildContext context, String url, dynamic error) {
+    print(error);
+    return const Center(child: Icon(Icons.error));
+  }
 }
+
+const List<Tuple2> _menuEntries = const <Tuple2>[
+  const Tuple2('Grid', Icons.grid_on),
+  //const Tuple2('List', Icons.list),
+];

--- a/lib/cache_manager/resize_cache_manager.dart
+++ b/lib/cache_manager/resize_cache_manager.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+import 'dart:developer';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_native_image/flutter_native_image.dart';
+import 'package:optimized_cached_image/image_transformer/resize_image_transformer.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:quiver/collection.dart';
+
+import '../image_cache_manager.dart';
+
+class ResizeImageCacheManager extends BaseCacheManager {
+  final ResizeImageCacheConfig cacheConfig;
+  final ImageTransformer transformer;
+  final _TAG = (ResizeImageCacheManager).toString();
+
+  final LruMap<int, Uint8List> _lruMemoryCache = new LruMap(maximumSize: 500);
+
+  @override
+  Future<String> getFilePath() async {
+    if (cacheConfig.storagePath != null) {
+      final Directory directory = await cacheConfig.storagePath;
+      return directory.path;
+    } else {
+      final Directory directory = await getTemporaryDirectory();
+      return p.join(directory.path, key);
+    }
+  }
+
+  static const key = 'libCachedImageData';
+
+  static ResizeImageCacheManager _instance;
+
+  /// The ScaledCacheManager that can be easily used directly. The code of
+  /// this implementation can be used as inspiration for more complex cache
+  /// managers.
+  factory ResizeImageCacheManager(
+      {ResizeImageCacheConfig cacheConfig, ImageTransformer transformer}) {
+    final config = cacheConfig ?? ResizeImageCacheConfig();
+    _instance ??= ResizeImageCacheManager._(
+        config, transformer ?? ResizeImageTransformer(config));
+    return _instance;
+  }
+
+  /// A named initializer for when clients wish to initialize the manager with custom config.
+  /// This is purely for syntax purposes.
+  factory ResizeImageCacheManager.init(
+      {ResizeImageCacheConfig cacheConfig, ImageTransformer transformer}) {
+    return ResizeImageCacheManager(
+        cacheConfig: cacheConfig, transformer: transformer);
+  }
+
+  ResizeImageCacheManager._(this.cacheConfig, this.transformer) : super(key);
+
+  ///Download the file and add to cache
+  @override
+  Future<FileInfo> downloadFile(String url,
+      {Map<String, String> authHeaders,
+      bool force = false,
+      BoxConstraints constraints}) async {
+    log('downloadFile, with url: $url', name: _TAG);
+    var response =
+        await super.downloadFile(url, authHeaders: authHeaders, force: force);
+    response = constraints != null
+        ? await transformer.transform(
+            response, {ResizeImageTransformer.SIZE_PARAM: constraints})
+        : response;
+    return response;
+  }
+
+  /// Get the file from the cache and/or online, depending on availability and age.
+  /// Downloaded form [url], [headers] can be used for example for authentication.
+  /// The files are returned as stream. First the cached file if available, when the
+  /// cached file is too old the newly downloaded file is returned afterwards.
+  ///
+  /// The [FileResponse] is either a [FileInfo] object for fully downloaded files
+  /// or a [DownloadProgress] object for when a file is being downloaded.
+  /// The [DownloadProgress] objects are only dispatched when [withProgress] is
+  /// set on true and the file is not available in the cache. When the file is
+  /// returned from the cache there will be no progress given, although the file
+  /// might be outdated and a new file is being downloaded in the background.
+  @override
+  Stream<FileResponse> getFileStream(String url,
+      {Map<String, String> headers,
+      bool withProgress,
+      Constraints constraints}) {
+    final downStream = StreamController<FileResponse>();
+    if (_lruMemoryCache.containsKey(url.hashCode)) {
+      log('getFileStream, memory cached, $url', name: _TAG);
+      downStream.add(ImageMemoryResponse(_lruMemoryCache[url.hashCode], url));
+    } else {
+      fileStream(downStream, url, headers, withProgress, constraints);
+    }
+
+    return downStream.stream;
+  }
+
+  void fileStream(
+      StreamController<FileResponse> downStream,
+      String url,
+      Map<String, String> headers,
+      bool withProgress,
+      BoxConstraints constraints) {
+    final upStream =
+        super.getFileStream(url, headers: headers, withProgress: withProgress);
+
+    var isUpStreamClosed = false;
+    upStream.listen((info) async {
+      if (info is FileInfo) {
+        log('getFileStream, with $url', name: _TAG);
+        File file = (info as FileInfo).file;
+        if (file.existsSync()) {
+          ImageProperties imageProperties =
+              await FlutterNativeImage.getImageProperties(file.path);
+
+          if (constraints != null) {
+            var targetWidth = constraints.maxWidth;
+            var targetHeight = constraints.maxHeight;
+            if (targetHeight == double.infinity &&
+                targetWidth != double.infinity) {
+              targetHeight = imageProperties.height /
+                  (imageProperties.width / targetWidth);
+
+              constraints = BoxConstraints(
+                  maxWidth: targetWidth, maxHeight: targetHeight);
+            }
+          }
+
+          if (constraints != null &&
+              math.min(imageProperties.width, imageProperties.height) >
+                  math.min(constraints.maxWidth, constraints.maxHeight)) {
+            log('getFileStream, srs dimension width: ${imageProperties.width} and height: ${imageProperties.height}',
+                name: _TAG);
+
+            info = await transformer.transform(
+                info, {ResizeImageTransformer.SIZE_PARAM: constraints});
+          } else {
+            log('getFileStream, use cached file', name: _TAG);
+          }
+
+          Uint8List bytes = file.readAsBytesSync();
+          _lruMemoryCache[url.hashCode] = bytes;
+        }
+      }
+      downStream.add(info);
+      if (isUpStreamClosed) {
+        unawaited(downStream.close());
+      }
+    }, onError: (e) {
+      downStream.addError(e);
+      downStream.close();
+    }, onDone: () {
+      isUpStreamClosed = true;
+    });
+  }
+
+  bool containsMemoryCache(String url) {
+    return _lruMemoryCache.containsKey(url.hashCode);
+  }
+
+  Uint8List getMemoryCache(String url) {
+    return _lruMemoryCache[url.hashCode];
+  }
+}
+
+class ResizeImageCacheConfig {
+  /// Storage path for cache
+  final Future<Directory> storagePath;
+
+  ResizeImageCacheConfig({this.storagePath});
+}
+
+class ImageMemoryResponse extends FileResponse {
+  ImageMemoryResponse(this.imageBytes, String originalUrl) : super(originalUrl);
+
+  final Uint8List imageBytes;
+}

--- a/lib/image_transformer.dart
+++ b/lib/image_transformer.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'image_cache_manager.dart';
 
 class DefaultImageTransformer extends ImageTransformer {
+  static const URL_PARAM = 'url';
   final ImageCacheConfig config;
 
   DefaultImageTransformer(this.config);
@@ -30,9 +31,11 @@ class DefaultImageTransformer extends ImageTransformer {
   };
 
   @override
-  Future<FileInfo> transform(FileInfo info, String uri) async {
-    final dimens = _getDimensionsFromUrl(uri);
-    await _scaleImageFile(info, dimens[0], dimens[1]);
+  Future<FileInfo> transform(FileInfo info, Map params) async {
+    if (params.containsKey(URL_PARAM)) {
+      final dimens = _getDimensionsFromUrl(params[URL_PARAM]);
+      await _scaleImageFile(info, dimens[0], dimens[1]);
+    }
     return info;
   }
 
@@ -61,7 +64,8 @@ class DefaultImageTransformer extends ImageTransformer {
       final format = _compressionFormats[extension] ?? CompressFormat.png;
       final tmpFile = getTempFile(file, format);
       final srcSize = file.lengthSync();
-      File resizedFile = await FlutterImageCompress.compressAndGetFile(file.path, tmpFile.path,
+      File resizedFile = await FlutterImageCompress.compressAndGetFile(
+          file.path, tmpFile.path,
           minWidth: minWidth, minHeight: minHeight, format: format);
       if (resizedFile != null && resizedFile.existsSync()) {
         if (resizedFile.lengthSync() < srcSize) {

--- a/lib/image_transformer/resize_image_transformer.dart
+++ b/lib/image_transformer/resize_image_transformer.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'dart:developer';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:flutter_native_image/flutter_native_image.dart';
+import 'package:path/path.dart' as p;
+
+import '../cache_manager/resize_cache_manager.dart';
+import '../image_cache_manager.dart';
+
+class ResizeImageTransformer extends ImageTransformer {
+  static const SIZE_PARAM = 'size';
+  final _TAG = (ResizeImageTransformer).toString();
+  final ResizeImageCacheConfig config;
+
+  final tmpFileSuffix = '.tmp';
+
+  ResizeImageTransformer(this.config);
+
+  final _compressionFormats = {
+    '.jpg': CompressFormat.jpeg,
+    '.jpeg': CompressFormat.jpeg,
+    '.webp': CompressFormat.webp,
+    '.png': CompressFormat.png,
+    '.heic': CompressFormat.heic,
+  };
+  final _extensionFormats = {
+    CompressFormat.jpeg: '.jpg',
+    CompressFormat.webp: '.webp',
+    CompressFormat.png: '.png',
+    CompressFormat.heic: '.heic'
+  };
+
+  @override
+  Future<FileInfo> transform(FileInfo info, Map params) async {
+    log('transform', name: _TAG);
+
+    BoxConstraints constraints = params[SIZE_PARAM];
+
+    File file = info.file;
+    if (file.existsSync()) {
+      ImageProperties imageProperties =
+          await FlutterNativeImage.getImageProperties(file.path);
+
+      log('transform, src dimension width: ${imageProperties.width} and height: ${imageProperties.height}',
+          name: _TAG);
+
+      var width = constraints.maxWidth;
+      var height = constraints.maxHeight;
+
+      await _scaleImageFile(info, width?.toInt(), height?.toInt());
+    }
+    return info;
+  }
+
+  Future<FileInfo> _scaleImageFile(FileInfo info, int width, int height) async {
+    File file = info.file;
+    String extension = p.extension(file.path) ?? '';
+    final format = _compressionFormats[extension] ?? CompressFormat.png;
+    final destPath = file.path + tmpFileSuffix + _extensionFormats[format];
+    final tmpFile = File(destPath);
+    final srcSize = file.lengthSync();
+    final screen = window.physicalSize;
+    File resizedFile = await FlutterImageCompress.compressAndGetFile(
+        file.path, tmpFile.path,
+        minWidth: width ?? screen.width.toInt(),
+        minHeight: height ?? screen.height.toInt(),
+        format: format,
+        quality: 75);
+
+    if (resizedFile == null) return info;
+
+    ImageProperties imageProperties =
+        await FlutterNativeImage.getImageProperties(resizedFile.path);
+
+    log('_scaleImageFile, scaled to a dimension, width: ${imageProperties.width} and height: ${imageProperties.height}',
+        name: _TAG);
+    if (resizedFile.lengthSync() < srcSize) {
+      resizedFile.renameSync(file.path);
+    } else {
+      resizedFile.deleteSync();
+    }
+
+    return info;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,12 +16,14 @@ dependencies:
   path_provider: ^1.6.5
   path: ^1.6.4
   pedantic: ^1.5.0
+  tuple: ^1.0.3
+  flutter_native_image: ^0.0.5
+  quiver: ^2.1.3
 
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: 1.9.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Hi @humblerookie,

Im Android dev and currently investigating Flutter for further migration on production.
And faced a problem with large images on my project that I've been doing. The problem is that images with high res are slowing down the Grid widget when scrolling. 

Here my changes  those I would like to add:

1. Resize source image if it is bigger then widget Constraints;
2. Add sample with the Grid widget;
3. Small optimization of the OptimizedCacheImage.

With the changes Images behave quite good. And I see next point to improve after I checkout your branch.

There are duplicate code of transformer classes like ResizeImageCacheManager and DefaultImageTransformer.

Implement LRU cache with the Expando api. I done something similar on Android but stuck on Flutter but I'm not exactly understanding it at the record pace.

Some optimization of the OptimizedCacheImage. I would prefer moving url transformation to the appropriate cache manager. 

Thank you