### PR TITLE
limited support for gifs, they're compressed and encoded into webp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2-alpha
+
+* Limited gif support. Gifs are compressed into webp and rendered as of now.
+
 ## 2.0.1
 
 * Update to null safety package dependencies. OCI still needs to migrate code to respect null safety. Additionally fix issue with hero widgets

--- a/example/lib/plugin_example/basic_content.dart
+++ b/example/lib/plugin_example/basic_content.dart
@@ -14,7 +14,7 @@ class BasicContent extends StatelessWidget {
             _sizedContainer(
               const Image(
                 image: OptimizedCacheImageProvider(
-                  'https://via.placeholder.com/350x150',
+                  "https://sample-videos.com/gif/3.gif",
                 ),
               ),
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.2-alpha"
   path:
     dependency: transitive
     description:

--- a/lib/src/transformer/image_transformer.dart
+++ b/lib/src/transformer/image_transformer.dart
@@ -19,8 +19,9 @@ class DefaultImageTransformer extends ImageTransformer {
     '.jpg': CompressFormat.jpeg,
     '.jpeg': CompressFormat.jpeg,
     '.webp': CompressFormat.webp,
+    '.gif': CompressFormat.webp,
     '.png': CompressFormat.png,
-    '.heic': CompressFormat.heic,
+    '.heic': CompressFormat.heic
   };
   final _extensionFormats = {
     CompressFormat.jpeg: '.jpg',
@@ -28,7 +29,7 @@ class DefaultImageTransformer extends ImageTransformer {
     CompressFormat.png: '.png',
     CompressFormat.heic: '.heic'
   };
-
+  final _skippedFormats = {'.gif': true};
   @override
   Future<FileInfo> transform(FileInfo info, int width, int height) async {
     final value = await _scaleImageFile(info, width, height);
@@ -40,7 +41,8 @@ class DefaultImageTransformer extends ImageTransformer {
     final file = fileInfo.file;
     log("Scaling file.. ${fileInfo.originalUrl}");
     var resizedFile = file;
-    if (file.existsSync() && (width != null || height != null)) {
+    final canResize = file.existsSync() && (width != null || height != null);
+    if (canResize) {
       final scaleInfo = getScaledFileInfo(file, width, height);
       final srcSize = file.lengthSync();
       log("Dimensions width=${scaleInfo.width}, height=${scaleInfo.height}, format ${scaleInfo.compressFormat}");
@@ -52,6 +54,7 @@ class DefaultImageTransformer extends ImageTransformer {
           quality: 90);
       final localFileSystem = fileIo.LocalFileSystem();
       resizedFile = localFileSystem.file(scaleInfo.file.path);
+
       if (resizedFile != null && resizedFile.existsSync()) {
         if (resizedFile.lengthSync() < srcSize) {
           log("Resized success ${fileInfo.originalUrl}");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: optimized_cached_image
 description: A library for loading images from network, resizing as per container size and caching while being memory sensitive.
-version: 2.0.1
+version: 2.0.2-alpha
 homepage: https://github.com/humblerookie/optimized_cached_image
 
 environment:


### PR DESCRIPTION
Flutter Image Compress only allows a handful of compression formats, gifs can be encoded into webp so this works seamlessly.