### PR TITLE
fix(*): avoid unnecessary null checks

### DIFF
--- a/lib/src/image_provider/_image_provider_io.dart
+++ b/lib/src/image_provider/_image_provider_io.dart
@@ -129,7 +129,7 @@ class OptimizedCacheImageProvider
       // have had a chance to track the key in the cache at all.
       // Schedule a microtask to give the cache a chance to add the key.
       scheduleMicrotask(() {
-        PaintingBinding.instance?.imageCache?.evict(key);
+        PaintingBinding.instance.imageCache?.evict(key);
       });
 
       errorListener?.call();

--- a/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/lib/src/image_provider/multi_image_stream_completer.dart
@@ -151,7 +151,7 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
       return;
     }
     _frameCallbackScheduled = true;
-    SchedulerBinding.instance?.scheduleFrameCallback(_handleAppFrame);
+    SchedulerBinding.instance.scheduleFrameCallback(_handleAppFrame);
   }
 
   void _emitFrame(ImageInfo imageInfo) {


### PR DESCRIPTION
<img width="1693" alt="image" src="https://user-images.githubusercontent.com/16430299/170086974-95ac327a-b9fd-4ed9-8e3a-ea32fa43a146.png">


This PR fixes these warnings.