### PR TITLE
Apply device pixel ratio to all width & height values

### DIFF
--- a/lib/src/oci_widget.dart
+++ b/lib/src/oci_widget.dart
@@ -1,5 +1,4 @@
 import 'package:optimized_cached_image/optimized_cached_image.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -249,18 +248,24 @@ class OptimizedCacheImage extends StatelessWidget {
     }
 
     return LayoutBuilder(builder: (ctx, constraints) {
-      var _constrainWidth = width?.toInt() ?? maxWidthDiskCache;
-      var _constrainHeight = height?.toInt() ?? maxHeightDiskCache;
+      int? _constrainWidth = width?.toInt() ?? maxWidthDiskCache;
+      int? _constrainHeight = height?.toInt() ?? maxHeightDiskCache;
 
-      final ratio = MediaQuery.of(context).devicePixelRatio;
       if (_constrainWidth == null && _constrainHeight == null) {
         _constrainWidth = constraints.maxWidth != double.infinity
-            ? (constraints.maxWidth * ratio).toInt()
+            ? constraints.maxWidth.toInt()
             : null;
         _constrainHeight = constraints.maxHeight != double.infinity
-            ? (constraints.maxHeight * ratio).toInt()
+            ? constraints.maxHeight.toInt()
             : null;
       }
+
+      final ratio = MediaQuery.of(context).devicePixelRatio;
+      _constrainWidth =
+          _constrainWidth != null ? (_constrainWidth * ratio).toInt() : null;
+      _constrainHeight =
+          _constrainHeight != null ? (_constrainHeight * ratio).toInt() : null;
+
       if (_image == null ||
           _image?.maxHeight != _constrainHeight ||
           _image?.maxWidth != _constrainHeight) {


### PR DESCRIPTION
This is a fix for small images that has really low quality when they are down scaled, see here: https://github.com/humblerookie/optimized_cached_image/issues/60
Bigger images have low quality too but there you don't notice it immediately.